### PR TITLE
Add basic support for ESP-IDF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(SRCS_DIR "lib/zxing")
+
+file(GLOB_RECURSE CPP_SRCS "${SRCS_DIR}/*.cpp")
+file(GLOB_RECURSE C_SRCS "${SRCS_DIR}/*.c")
+
+idf_component_register(
+    SRCS ${C_SRCS} ${CPP_SRCS}
+    INCLUDE_DIRS ${SRCS_DIR}
+)
+
+target_compile_options(${COMPONENT_LIB}
+    PUBLIC
+        -Wno-missing-field-initializers
+    PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++20>
+)

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Additional steps to update the library:
 
 - Updated version.h manually because there is no project preprocessing
 - removed libzint directory (stibs) because is not used and caused compile error
+
+## Usage with ESP-IDF
+
+Simply this project as a dependency:
+
+    idf.py add-dependency --git https://github.com/rzeldent/micro-zxing.git micro-zxing


### PR DESCRIPTION
This PR adds a basic CMakeLists.txt, which allows easy adding this repo as a dependency to ESP-IDF based projects.

Also adds a short hint how to include this project as dependency via idf.py to the README.